### PR TITLE
Fix mockup layout in big screens

### DIFF
--- a/src/app/pages/landing/landing.component.scss
+++ b/src/app/pages/landing/landing.component.scss
@@ -10,7 +10,7 @@
   width: 1000px;
   max-width: calc(100vh * 1.825 - 280px);
   min-width: 720px;
-  transform: translate(calc(((1700px - 100vw)) / 2), -50%)
+  transform: translate(0, -50%)
 }
 
 .customizer {


### PR DESCRIPTION
![image](https://github.com/dimavroudis/wp-admin-colors/assets/21153327/f9809ba7-3c4a-4597-b3fd-48176815ee48)
